### PR TITLE
Implement DryRbMigration/IncludeDryTypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# 1.0.0-to-be-released
+
+Add new `DryRbMigration/IncludeDryTypes` cop. ([@Morozzzko][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,1 +1,7 @@
 # Write it!
+
+DryRbMigration/IncludeDryTypes:
+  Description: |
+    Replaces old-style `include Dry::Types.module` with `include Dry.Types`
+  Enabled: true
+  VersionAdded: '0.92'

--- a/lib/rubocop/cop/dry_rb_migration/include_dry_types.rb
+++ b/lib/rubocop/cop/dry_rb_migration/include_dry_types.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# TODO: when finished, run `rake generate_cops_documentation` to update the docs
+module RuboCop
+  module Cop
+    module DryRbMigration
+      # Replaces old-style `include Dry::Types.module` with `include Dry.Types`
+      #
+      # @example
+      #   # bad
+      #   include Dry::Types.module
+      #
+      #   # good
+      #   include Dry.Types
+      #   # good
+      #   include Dry::Types()
+      class IncludeDryTypes < Base
+        extend AutoCorrector
+        # TODO: Implement the cop in here.
+        #
+        # In many cases, you can use a node matcher for matching node pattern.
+        # See https://github.com/rubocop-hq/rubocop-ast/blob/master/lib/rubocop/ast/node_pattern.rb
+        #
+        # For example
+        MSG = 'Replace with include Dry.Types'
+
+        def_node_matcher :includes_dry_types_old_style?, <<~PATTERN
+          (send _ :include
+            $(send
+              (const
+                (const nil? :Dry) :Types) :module))
+        PATTERN
+
+        def on_send(node)
+          includes_dry_types_old_style?(node) do |included_method|
+            add_offense(node) do |corrector|
+              corrector.replace(included_method, "Dry.Types")
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/dryrbmigration_cops.rb
+++ b/lib/rubocop/cop/dryrbmigration_cops.rb
@@ -1,1 +1,2 @@
 # frozen_string_literal: true
+require_relative 'dry_rb_migration/include_dry_types'

--- a/spec/rubocop/cop/dry_rb_migration/include_dry_types_spec.rb
+++ b/spec/rubocop/cop/dry_rb_migration/include_dry_types_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::DryRbMigration::IncludeDryTypes do
+  subject(:cop) { described_class.new(config) }
+
+  let(:config) { RuboCop::Config.new }
+
+  it 'registers an offense when using old-style include' do
+    expect_offense(<<~RUBY)
+      include Dry::Types.module
+      ^^^^^^^^^^^^^^^^^^^^^^^^^ Replace with include Dry.Types
+    RUBY
+    expect_correction(<<~RUBY)
+      include Dry.Types
+    RUBY
+  end
+
+  it 'registers an offense when using old-style include on an explicit module' do
+    expect_offense(<<~RUBY)
+      Foo.include Dry::Types.module
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Replace with include Dry.Types
+    RUBY
+    expect_correction(<<~RUBY)
+      Foo.include Dry.Types
+    RUBY
+  end
+
+  it 'does not trigger on weird style' do
+    expect_no_offenses(<<~RUBY)
+      include Dry::Types()
+    RUBY
+  end
+
+  it 'does not trigger on new style' do
+    expect_no_offenses(<<~RUBY)
+      include Dry.Types(default: :nominal)
+    RUBY
+  end
+end


### PR DESCRIPTION
Replaces old-style `include Dry::Types.module` with `include Dry.Types`